### PR TITLE
Aprimorado o repositório

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,124 @@
-Script simples para fazer download de músicas/vídeos do YouTube.
+# Script de Youtube DL
 
-criado para funcionar em Linux.
-Necessário YouTube-dl e ffmpeg para a conversão dos vídeos.
+Um script simples para baixar/transferir músicas/vídeos do YouTube.
 
+- [Script de Youtube DL](#script-de-youtube-dl)
+    - [Observação](#observação)
+      - [`youtube-dl`](#youtube-dl)
+        - [Global](#global)
+        - [Alpine Linux](#alpine-linux)
+        - [Arch Linux e derivados de Arch Linux](#arch-linux-e-derivados-de-arch-linux)
+        - [CentOS](#centos)
+        - [Debian e derivados de Debian](#debian-e-derivados-de-debian)
+        - [Fedora e derivados de Fedora](#fedora-e-derivados-de-fedora)
+        - [openSUSE](#opensuse)
+        - [Solus](#solus)
+      - [`ffmpeg`](#ffmpeg)
+        - [Variados](#variados)
+        - [CentOS, Fedora e derivados de Fedora](#centos-fedora-e-derivados-de-fedora)
+    - [Instruções](#instruções)
+
+### Observação
+- Funciona apenas em Linux e nos sistemas Unix, inclusive FreeBSD. Deve funcionar no WSL do Windows.
+- É necessário `youTube-dl` e `ffmpeg` para a conversão dos vídeos.
+
+#### `youtube-dl`
+
+##### Global
+
+```bash
 pip install youtube-dl
-sudo apt-get install ffmpeg
+```
 
-apenas execute o script python ytdl.py e siga os passos
+##### Alpine Linux
+
+```bash
+apk update
+apk add --upgrade youtube-dl
+```
+
+##### Arch Linux e derivados de Arch Linux
+
+```bash
+# pacman
+sudo pacman youtube-dl
+
+# yay - o último commit do repositório
+youtube-dl-git
+```
+
+##### CentOS
+
+Baixa/transfere [aqui](http://download-ib01.fedoraproject.org/pub/epel/8/Everything/aarch64/)
+
+```bash
+rpm -Uvh epel-release*rpm
+dnf install youtube-dl
+```
+
+##### Debian e derivados de Debian
+
+```bash
+sudo apt install youtube-dl
+```
+
+##### Fedora e derivados de Fedora
+
+```bash
+sudo dnf install youtube-dl
+```
+
+##### openSUSE
+
+```bash
+sudo zypper install youtube-dl
+```
+
+##### Solus
+
+```bash
+sudo eopkg install youtube-dl
+```
+
+#### `ffmpeg`
+
+##### Variados
+
+```bash
+# Alpine Linux
+apk add --upgrade ffmpeg
+
+# Arch Linux
+sudo pacman -Syu ffmpeg
+
+# Debian e derivados de Debian
+sudo apt install ffmpeg
+
+# FreeBSD
+pkg install ffmpeg
+
+# Mageia
+urpmi ffmpeg
+
+# openSUSE
+sudo zypper install ffmpeg-4
+
+# Solus
+sudo eopkg dr Solus
+sudo eopkg rr Solus
+sudo eopkg ar Solus https://mirrors.rit.edu/solus/packages/unstable/eopkg-index.xml.xz
+sudo eopkg install ffmpeg
+```
+
+##### CentOS, Fedora e derivados de Fedora
+
+Baixe/transfira [aqui](http://download1.rpmfusion.org/free/fedora/).
+
+```bash
+rpm -Uvh rpmfusion-free-release-stable*rpm
+dnf --enablerepo=rpmfusion-free-rawhide install ffmpeg
+```
+
+### Instruções
+
+Após as inatalações necessárias, apenas execute o script `ytdl.py` e siga os passos. 

--- a/ytdl.py
+++ b/ytdl.py
@@ -2,10 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from os.path import expanduser
-import os
-import sys
+import os, sys, subprocess, textwrap
 import urllib.request, urllib.error, urllib.parse
-import subprocess
 
 #-------------------------------------
 # Criado por: Wolfterro
@@ -15,24 +13,66 @@ import subprocess
 #-------------------------------------
 
 version = "2.0.4"
-is_termux= "true"
+is_termux = "true"
+
+ajuda = f"""\
+==================================================
+Youtube-DL Script - Versão {version} - Python 3.x
+==================================================
+
+ * Este script requer o youtube-dl instalado e reconhecido como comando do shell
+ * O pacote 'libav' ou 'ffmpeg' deverá estar instalado para converter os vídeos baixados
+ * Caso não tenha o youtube-dl instalado, utilize a opção 'Instalar/Atualizar youtube-dl'
+ * É necessário privilégios de root para instalar e atualizar o youtube-dl"
+ * Utilize os formatos de conversão caso o formato escolhido não esteja disponível
+ 
+Uso: ./ytdl.py [Argumento]
+
+Argumentos:
+-----------
+
+ -h || --help			Mostra este menu de ajuda
+ 
+"""
+
+main_menu = f"""\
+	====================================================
+	Youtube-DL Script - Versão {version} - Python 3.x"
+	====================================================
+
+	Escolha uma das opções abaixo (qualquer outra tecla para sair):
+	---------------------------------------------------------------
+ 
+	Áudio (Conversão):
+	------------------
+ 
+	(1) Formato MP3
+	(2) Formato WAV
+	
+	Vídeo (Nativo):
+	---------------
+ 
+	(3) Formato MP4
+	(4) Formato WEBM
+	(5) Formato 3GP
+	(6) Formato MKV
+	
+	Vídeo (Conversão):
+	------------------
+ 
+	(7) Formato MP4
+	(8) Formato WEBM
+	(9) Formato MKV
+
+	Opções:
+	-------
+ 
+	(0) Instalar/Atualizar youtube-dl
+ 
+"""
 
 def help():
-	print("=============================================")
-	print("Youtube-DL Script - Versão %s - Python 3.x" % (version))
-	print("=============================================\n")
-
-	print(" * Este script requer o youtube-dl instalado e reconhecido como comando do shell")
-	print(" * O pacote 'libav' ou 'ffmpeg' deverá estar instalado para converter os vídeos baixados")
-	print(" * Caso não tenha o youtube-dl instalado, utilize a opção 'Instalar/Atualizar youtube-dl'")
-	print(" * É necessário privilégios de root para instalar e atualizar o youtube-dl")
-	print(" * Utilize os formatos de Conversão caso o formato escolhido não esteja disponível\n")
-
-	print("Uso: ./Youtube-DL-Script.py [Argumento]\n")
-
-	print("Argumentos:")
-	print("-----------")
-	print(" -h || --help\t\tMostra este menu de ajuda\n")
+	print(ajuda)
 
 def get_home_dir():
 	get_home = os.path.expanduser("/sdcard/Download/")
@@ -104,33 +144,7 @@ def youtube_dl_options(home_dir):
 		print("Saindo ...")
 
 def main_menu():
-	print("=============================================")
-	print("Youtube-DL Script - Versão %s - Python 3.x" % (version))
-	print("=============================================\n")
-
-	print("Escolha uma das opções abaixo (qualquer outra tecla para sair):")
-	print("---------------------------------------------------------------")
-	print("Áudio (Conversão):")
-	print("------------------")
-	print("(1) Formato MP3")
-	print("(2) Formato WAV\n")
-	
-	print("Vídeo (Nativo):")
-	print("---------------")
-	print("(3) Formato MP4")
-	print("(4) Formato WEBM")
-	print("(5) Formato 3GP")
-	print("(6) Formato MKV\n")
-	
-	print("Vídeo (Conversão):")
-	print("------------------")
-	print("(7) Formato MP4")
-	print("(8) Formato WEBM")
-	print("(9) Formato MKV\n")
-
-	print("Opções:")
-	print("-------")
-	print("(0) Instalar/Atualizar youtube-dl\n")
+	print(main_menu)
 
 	user_input = input("Escolha uma das opções acima: ")
 	return user_input


### PR DESCRIPTION
Olá @RafaelFernandesBR !

# Ficheiro `ydtl.py`

Fiz uma refactoração e código limpo de repetições de `print` para concatenar os parágrafos num único texto, utilizando `"""` entre um texto. Além disso, adicionei `f` para pegar as variáveis com colchetes dentro da frase sem precisar de `%d` e`%s`. Por exemplo:

```python
ajuda = f"""\
==================================================
Youtube-DL Script - Versão {version} - Python 3.x
==================================================

(...)
"""

def help():
	print(ajuda)
```

# Ficheiro `README.md`

Nem todos os utilizadores de Linux utilizam Ubuntu. Há utilizadores de milhares de distribuições de Linux, por isso, o comando utilizado no Ubuntu não deve funcionar noutras distribuições de Linux. Observe que Ubuntu é derivado de Debian. Também te lembras que Python com comandos de Shell Script também funciona no FreeBSD, macOS e nos sistemas Unix. 